### PR TITLE
Missing Code in val_ds  and close Parentheses

### DIFF
--- a/neuronales_netz_beispiel.ipynb
+++ b/neuronales_netz_beispiel.ipynb
@@ -72,7 +72,8 @@
     "    subset=\"validation\",\n",
     "    seed=1337,\n",
     "    image_size=image_size,\n",
-    "    ba"
+    "    batch_size=batch_size,\n",
+    ")\n",
    ]
   },
   {


### PR DESCRIPTION
Missing Code at the Generate Dataset
"    batch_size=batch_size,\n",
    ")\n",